### PR TITLE
Remove: excess explicit returns in linked_list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
     simplecov_json_formatter (0.1.4)
 
 PLATFORMS
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -10,14 +10,14 @@ class LinkedList
     @head.nil? ? count = 0 : count = 1
     current_node = @head
     count += 1 while current_node = current_node.next_node
-    return count
+    count
   end
 
   def to_string
     return "List empty!" if head.nil?
     string = ""; current_node = head; i = self.count
     i.times { string.concat("#{current_node.data} "); current_node = current_node.next_node }
-    return string.rstrip
+    string.rstrip
   end
 
   def append(value)
@@ -38,7 +38,7 @@ class LinkedList
     current_node = current_node.next_node until current_node.next_node.next_node.nil?
     popped_node = current_node.next_node
     current_node.add_next(nil)
-    return popped_node.data
+    popped_node.data
   end
 
   def prepend(value)
@@ -60,7 +60,7 @@ class LinkedList
     collection = to_string.split(" ")
     substring = ""
     (index..index + quantity - 1).each { |i| substring.concat(collection[i], ' ') }
-    return substring.strip
+    substring.strip
   end
 
   def includes?(string)


### PR DESCRIPTION
## Issue(s)

 None

## Type of change

    [] New feature
    [] Bug Fix
    [x] Refactor

## Description of Change/How Issue Was Resolved

 Tested which explicit returns were necessary to break out of the method, and which could be replaced with implicit technique

## What I've Learned

"Just because something works, doesn't mean it's best practice" -Cydnee Owens :)


## Additional Notes

Notes...
